### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,8 @@ jobs:
 
   # Check with Home Assistant's hassfest
   hassfest:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     name: Hassfest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/rknightion/meraki-dashboard-ha/security/code-scanning/3](https://github.com/rknightion/meraki-dashboard-ha/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `hassfest` job. Since the job only checks out code and runs a validation tool, it likely only requires `contents: read` permissions. This change ensures that the job adheres to the principle of least privilege and does not inherit overly permissive repository-level permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
