### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
       - main
       - dev
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.13"
 


### PR DESCRIPTION
Potential fix for [https://github.com/rknightion/meraki-dashboard-ha/security/code-scanning/6](https://github.com/rknightion/meraki-dashboard-ha/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, it appears that the jobs primarily involve checking out code and running validations, which typically require `contents: read` permission. If any job requires additional permissions (e.g., `pull-requests: write`), those can be specified at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
