### PR TITLE
Increase repairs flow test coverage

### DIFF
--- a/tests/test_config_migration_and_hub_config.py
+++ b/tests/test_config_migration_and_hub_config.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.meraki_dashboard.config.hub_config import (
+    HubConfigurationManager,
+)
+from custom_components.meraki_dashboard.config.migration import (
+    ConfigMigration,
+    async_migrate_config_entry,
+)
+from custom_components.meraki_dashboard.const import (
+    CONF_AUTO_DISCOVERY,
+    CONF_DISCOVERY_INTERVAL,
+    CONF_DYNAMIC_DATA_INTERVAL,
+    CONF_HUB_AUTO_DISCOVERY,
+    CONF_HUB_DISCOVERY_INTERVALS,
+    CONF_HUB_SCAN_INTERVALS,
+    CONF_SCAN_INTERVAL,
+    CONF_SEMI_STATIC_DATA_INTERVAL,
+    CONF_STATIC_DATA_INTERVAL,
+    DEFAULT_DISCOVERY_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+)
+
+
+@pytest.mark.asyncio
+async def test_convert_intervals_to_seconds(hass: HomeAssistant, mock_config_entry: ConfigEntry):
+    migration = ConfigMigration(hass, mock_config_entry)
+    options = {
+        CONF_SCAN_INTERVAL: 5,  # minutes
+        CONF_DISCOVERY_INTERVAL: 120,  # already seconds
+        CONF_STATIC_DATA_INTERVAL: 30,
+        CONF_SEMI_STATIC_DATA_INTERVAL: 15,
+        CONF_DYNAMIC_DATA_INTERVAL: 2,
+        CONF_HUB_SCAN_INTERVALS: {"hub1": 10},
+        CONF_HUB_DISCOVERY_INTERVALS: {"hub1": 20},
+    }
+    result = migration._convert_intervals_to_seconds(options)
+    assert result[CONF_SCAN_INTERVAL] == 300
+    assert result[CONF_DISCOVERY_INTERVAL] == 120
+    assert result[CONF_STATIC_DATA_INTERVAL] == 1800
+    assert result[CONF_SEMI_STATIC_DATA_INTERVAL] == 900
+    assert result[CONF_DYNAMIC_DATA_INTERVAL] == 120
+    assert result[CONF_HUB_SCAN_INTERVALS]["hub1"] == 600
+    assert result[CONF_HUB_DISCOVERY_INTERVALS]["hub1"] == 1200
+
+
+async def test_async_migrate_to_version_2_adds_defaults(hass: HomeAssistant):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    entry = MockConfigEntry(domain="meraki_dashboard", data={}, options={}, entry_id="test")
+    migration = ConfigMigration(hass, entry)
+    with patch.object(hass.config_entries, "async_update_entry", MagicMock()) as mock_update:
+        await migration.async_migrate_to_version_2()
+        updated_options = mock_update.call_args.kwargs["options"]
+        assert updated_options[CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+        assert updated_options[CONF_DISCOVERY_INTERVAL] == DEFAULT_DISCOVERY_INTERVAL
+        assert updated_options[CONF_STATIC_DATA_INTERVAL] > 0
+        assert updated_options[CONF_HUB_SCAN_INTERVALS] == {}
+        assert updated_options[CONF_HUB_AUTO_DISCOVERY] == {}
+
+@pytest.mark.asyncio
+async def test_async_migrate_config_entry_handles_no_version(hass: HomeAssistant):
+    entry = MagicMock(spec=ConfigEntry)
+    entry.version = None
+    with patch.object(hass.config_entries, "async_update_entry") as mock_update, patch("custom_components.meraki_dashboard.config.migration.ConfigMigration", autospec=True) as mock_cls:
+        instance = mock_cls.return_value
+        instance.async_migrate.return_value = True
+        result = await async_migrate_config_entry(hass, entry)
+        mock_update.assert_called_with(entry, version=1)
+        instance.async_migrate.assert_awaited_once()
+        assert result is True
+
+def test_build_schema_dict_global_auto_discovery():
+    manager = HubConfigurationManager({CONF_AUTO_DISCOVERY: False})
+    schema = manager.build_schema_dict({})
+    keys = [marker.schema for marker in schema.keys()]
+    assert keys == [CONF_AUTO_DISCOVERY]
+    assert schema[next(iter(schema))] is bool
+
+
+def test_build_schema_dict_with_hubs():
+    manager = HubConfigurationManager({})
+    hubs_info = {"hub1": {"network_name": "Net1", "device_type": "MT", "device_count": 1}}
+    schema = manager.build_schema_dict(hubs_info)
+    keys = {marker.schema for marker in schema}
+    assert "auto_discovery_Net1 (MT)" in keys
+    assert "scan_interval_Net1 (MT)" in keys
+    assert "discovery_interval_Net1 (MT)" in keys
+    assert CONF_STATIC_DATA_INTERVAL in keys
+    assert CONF_SEMI_STATIC_DATA_INTERVAL in keys
+    assert CONF_DYNAMIC_DATA_INTERVAL in keys
+
+
+def test_convert_legacy_intervals_to_seconds():
+    options = {
+        CONF_SCAN_INTERVAL: 1,
+        CONF_DISCOVERY_INTERVAL: 2,
+        CONF_STATIC_DATA_INTERVAL: 3,
+        CONF_SEMI_STATIC_DATA_INTERVAL: 4,
+        CONF_DYNAMIC_DATA_INTERVAL: 5,
+    }
+    result = HubConfigurationManager.convert_legacy_intervals_to_seconds(options)
+    assert result[CONF_SCAN_INTERVAL] == 60
+    assert result[CONF_DISCOVERY_INTERVAL] == 120
+    assert result[CONF_STATIC_DATA_INTERVAL] == 180
+    assert result[CONF_SEMI_STATIC_DATA_INTERVAL] == 240
+    assert result[CONF_DYNAMIC_DATA_INTERVAL] == 300
+

--- a/tests/test_repairs_flows_additional.py
+++ b/tests/test_repairs_flows_additional.py
@@ -1,0 +1,137 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.meraki_dashboard.const import DOMAIN
+from custom_components.meraki_dashboard.repairs import (
+    ApiKeyExpiredRepairFlow,
+    DeviceDiscoveryFailedRepairFlow,
+    NetworkAccessLostRepairFlow,
+)
+
+
+@pytest.mark.asyncio
+async def test_extract_config_entry_id_edge_cases(hass: HomeAssistant):
+    flow = ApiKeyExpiredRepairFlow(hass, "issue", {"config_entry_id": 123})
+    assert flow._extract_config_entry_id({"config_entry_id": 123}) == "123"
+    assert flow._extract_config_entry_id({"config_entry_id": "abc"}) == "abc"
+    assert flow._extract_config_entry_id({}) is None
+    assert flow._extract_config_entry_id(None) is None
+
+
+@pytest.mark.asyncio
+async def test_description_placeholders_defaults(hass: HomeAssistant):
+    flow = NetworkAccessLostRepairFlow(
+        hass,
+        "issue",
+        {"config_entry_title": 1, "network_name": None},
+    )
+    placeholders = flow._get_description_placeholders()
+    assert placeholders["config_entry_title"] == "Unknown"
+    assert placeholders["network_name"] == "Unknown"
+
+
+@pytest.mark.asyncio
+async def test_apikey_flow_async_step_init(hass: HomeAssistant, mock_config_entry):
+    with patch.object(hass.config_entries, "async_get_entry", return_value=mock_config_entry), patch.object(
+        hass.config_entries.flow, "async_init", AsyncMock(return_value=None)
+    ), patch("custom_components.meraki_dashboard.repairs.ir.async_delete_issue") as delete_issue:
+        flow = ApiKeyExpiredRepairFlow(
+            hass,
+            "api_key_expired_test",
+            {"config_entry_id": mock_config_entry.entry_id, "config_entry_title": "Test"},
+        )
+        result = await flow.async_step_init(user_input={})
+        delete_issue.assert_called_once_with(hass, DOMAIN, "api_key_expired_test")
+        hass.config_entries.flow.async_init.assert_called_once()
+        assert result["type"] == "create_entry"
+
+
+@pytest.mark.asyncio
+async def test_network_access_flow_async_step_init(hass: HomeAssistant, mock_config_entry):
+    with patch.object(hass.config_entries, "async_get_entry", return_value=mock_config_entry), patch.object(
+        hass.config_entries, "async_reload", AsyncMock(return_value=True)
+    ), patch("custom_components.meraki_dashboard.repairs.ir.async_delete_issue") as delete_issue:
+        flow = NetworkAccessLostRepairFlow(
+            hass,
+            "network_access_lost_test",
+            {"config_entry_id": mock_config_entry.entry_id, "network_name": "Net"},
+        )
+        result = await flow.async_step_init(user_input={})
+        delete_issue.assert_called_once_with(hass, DOMAIN, "network_access_lost_test")
+        from typing import Any, cast
+
+        cast(Any, hass.config_entries.async_reload).assert_called_once_with(
+            mock_config_entry.entry_id
+        )
+        assert result["type"] == "create_entry"
+
+
+@pytest.mark.asyncio
+async def test_device_discovery_flow_async_step_init(hass: HomeAssistant, mock_config_entry):
+    hub = MagicMock()
+    hub.hub_name = "Hub1"
+    hub._async_discover_devices = AsyncMock()
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: {"network_hubs": {"hub1": hub}}}
+    with patch("custom_components.meraki_dashboard.repairs.ir.async_delete_issue") as delete_issue:
+        flow = DeviceDiscoveryFailedRepairFlow(
+            hass,
+            "device_discovery_failed_test",
+            {"config_entry_id": mock_config_entry.entry_id, "hub_name": "Hub1"},
+        )
+        result = await flow.async_step_init(user_input={})
+        delete_issue.assert_called_once_with(hass, DOMAIN, "device_discovery_failed_test")
+        hub._async_discover_devices.assert_awaited_once()
+        assert result["type"] == "create_entry"
+
+
+@pytest.mark.asyncio
+async def test_apikey_flow_show_form_when_no_input(hass: HomeAssistant):
+    flow = ApiKeyExpiredRepairFlow(hass, "issue", {"config_entry_id": "123"})
+    result = await flow.async_step_init(user_input=None)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+
+@pytest.mark.asyncio
+async def test_apikey_get_description_placeholders_unknown(hass: HomeAssistant):
+    flow = ApiKeyExpiredRepairFlow(hass, "issue", {"config_entry_title": 123})
+    placeholders = flow._get_description_placeholders()
+    assert placeholders["config_entry_title"] == "Unknown"
+
+
+@pytest.mark.asyncio
+async def test_device_discovery_get_description_placeholders(hass: HomeAssistant):
+    flow = DeviceDiscoveryFailedRepairFlow(
+        hass,
+        "issue",
+        {"config_entry_title": "Title", "hub_name": 123},
+    )
+    placeholders = flow._get_description_placeholders()
+    assert placeholders["config_entry_title"] == "Title"
+    assert placeholders["hub_name"] == "Unknown"
+
+
+@pytest.mark.asyncio
+async def test_device_discovery_flow_async_step_init_failure(
+    hass: HomeAssistant, mock_config_entry
+):
+    hub = MagicMock()
+    hub.hub_name = "Hub1"
+    hub._async_discover_devices = AsyncMock(side_effect=Exception("fail"))
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: {"network_hubs": {"hub1": hub}}}
+    with patch(
+        "custom_components.meraki_dashboard.repairs.ir.async_delete_issue"
+    ) as delete_issue:
+        flow = DeviceDiscoveryFailedRepairFlow(
+            hass,
+            "device_discovery_failed_test_fail",
+            {"config_entry_id": mock_config_entry.entry_id, "hub_name": "Hub1"},
+        )
+        result = await flow.async_step_init(user_input={})
+        delete_issue.assert_called_once_with(
+            hass, DOMAIN, "device_discovery_failed_test_fail"
+        )
+        hub._async_discover_devices.assert_awaited_once()
+        assert result["type"] == "create_entry"


### PR DESCRIPTION
## Summary
- add new test suite covering repair flow classes
- expand tests to verify placeholder logic, form display, and error handling paths
- increase coverage for config migration and hub configuration utilities

## Testing
- `uv run ruff check --fix tests/test_config_migration_and_hub_config.py`
- `uv run mypy custom_components tests/test_config_migration_and_hub_config.py`
- `uv run pytest tests/test_config_migration_and_hub_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688621ecd79483219bf5baa82abf3b96